### PR TITLE
package.json: fix es module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "automaton",
     "automata"
   ],
-  "module": "src/index.js",
+  "source": "src/index.js",
+  "module": "dist/kingly.es.js",
   "main": "dist/kingly.umd.js",
   "unpkg": "dist/kingly.umd.js",
   "files": [


### PR DESCRIPTION
.. otherwise i get mysterious `ReferenceError`s in rollup and `import { createStateMachine } from "kingly"`
`@rollup/plugin-node-resolve` silently* fails to resolve the es module file, cos `src/index.js` is not in the npm package

\* actually its `sirv` the http server, who hides rollup's warning

```
$ npm run build
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
kingly (imported by src/main.js)
```

can be reproduced with my template repo at https://github.com/milahu/kingly-template-rollup